### PR TITLE
Update Edge/Nodes to Use TMPro

### DIFF
--- a/Assets/Scenes/Repl/Repl.unity
+++ b/Assets/Scenes/Repl/Repl.unity
@@ -427,8 +427,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 822623674}
   m_HandleRect: {fileID: 822623673}
   m_Direction: 0
-  m_Value: 0
-  m_Size: 1
+  m_Value: 1
+  m_Size: 0.9999999
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -607,7 +607,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 204299345}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c935dea8a2dcf70438d4dca364bbd0a2, type: 3}
+  m_Script: {fileID: 11500000, guid: 015532a2f74b3a84e9c8b49e4c8df7f7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -616,37 +616,41 @@ MonoBehaviour:
   NodeStyles:
   - Name: Noun
     Color: {r: 1, g: 1, b: 1, a: 1}
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     FontSize: 120
     FontStyle: 0
-    Prefab: {fileID: 0}
+    Prefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
+      type: 3}
   - Name: Verb
-    Color: {r: 1, g: 0.63512623, b: 0, a: 1}
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    Color: {r: 1, g: 0.7529412, b: 0, a: 1}
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     FontSize: 120
     FontStyle: 0
-    Prefab: {fileID: 0}
+    Prefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
+      type: 3}
   - Name: Error
     Color: {r: 1, g: 0, b: 0, a: 1}
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     FontSize: 120
-    FontStyle: 3
-    Prefab: {fileID: 0}
-  - Name: Adjective
-    Color: {r: 0, g: 1, b: 0.1408956, a: 1}
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    FontSize: 80
     FontStyle: 0
-    Prefab: {fileID: 0}
+    Prefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
+      type: 3}
+  - Name: Adjective
+    Color: {r: 0, g: 1, b: 0.1254902, a: 1}
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+    FontSize: 120
+    FontStyle: 0
+    Prefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
+      type: 3}
   EdgeStyles:
   - Name: default
-    Color: {r: 0, g: 1, b: 0.1826632, a: 1}
+    Color: {r: 0, g: 1, b: 0.1254902, a: 1}
     LineWidth: 10
     IsDirected: 1
     DrawEdge: 1
     ArrowheadLength: 7
     ArrowheadWidth: 7
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     FontSize: 80
     FontStyle: 0
     Prefab: {fileID: 0}
@@ -657,51 +661,7 @@ MonoBehaviour:
     DrawEdge: 1
     ArrowheadLength: 7
     ArrowheadWidth: 7
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    FontSize: 80
-    FontStyle: 0
-    Prefab: {fileID: 0}
-  - Name: can be
-    Color: {r: 0.5754717, g: 0.5673282, b: 0.5673282, a: 1}
-    LineWidth: 10
-    IsDirected: 1
-    DrawEdge: 1
-    ArrowheadLength: 7
-    ArrowheadWidth: 7
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    FontSize: 80
-    FontStyle: 0
-    Prefab: {fileID: 0}
-  - Name: is always
-    Color: {r: 0.5754717, g: 0.5673282, b: 0.5673282, a: 1}
-    LineWidth: 10
-    IsDirected: 1
-    DrawEdge: 1
-    ArrowheadLength: 7
-    ArrowheadWidth: 7
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    FontSize: 80
-    FontStyle: 0
-    Prefab: {fileID: 0}
-  - Name: mutually exclusive
-    Color: {r: 1, g: 0, b: 0, a: 1}
-    LineWidth: 10
-    IsDirected: 0
-    DrawEdge: 1
-    ArrowheadLength: 7
-    ArrowheadWidth: 7
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    FontSize: 80
-    FontStyle: 0
-    Prefab: {fileID: 0}
-  - Name: is never
-    Color: {r: 1, g: 0, b: 0, a: 1}
-    LineWidth: 10
-    IsDirected: 0
-    DrawEdge: 1
-    ArrowheadLength: 7
-    ArrowheadWidth: 7
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     FontSize: 80
     FontStyle: 0
     Prefab: {fileID: 0}
@@ -709,9 +669,9 @@ MonoBehaviour:
     type: 3}
   EdgePrefab: {fileID: 6472097822149504536, guid: 5f50d549902958c4bbfc257f338035d6,
     type: 3}
-  SpringStiffness: 30
-  RepulsionGain: 2000000
-  NodeDamping: 0.2
+  SpringStiffness: 1
+  RepulsionGain: 100000
+  NodeDamping: 0.5
   GreyOutFactor: 0.5
   Border: 100
   ToolTip: {fileID: 0}
@@ -1432,8 +1392,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1269615879}
   m_HandleRect: {fileID: 1269615878}
   m_Direction: 2
-  m_Value: 0.9999874
-  m_Size: 0.91499984
+  m_Value: 1.000009
+  m_Size: 0.915
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -1732,7 +1692,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 24.800049, y: 0.000030517578}
+  m_AnchoredPosition: {x: 24.800283, y: 0.000030517578}
   m_SizeDelta: {x: -49.6, y: 0}
   m_Pivot: {x: 0.5, y: 1.0000005}
 --- !u!114 &996344458
@@ -2261,28 +2221,29 @@ MonoBehaviour:
   m_GameObject: {fileID: 1392982997}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c935dea8a2dcf70438d4dca364bbd0a2, type: 3}
+  m_Script: {fileID: 11500000, guid: 015532a2f74b3a84e9c8b49e4c8df7f7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   NodeStyles:
-  - Name: default
+  - Name: Default
     Color: {r: 1, g: 1, b: 1, a: 1}
-    Font: {fileID: 0}
-    FontSize: 80
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+    FontSize: 120
     FontStyle: 0
-    Prefab: {fileID: 0}
+    Prefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
+      type: 3}
   EdgeStyles:
-  - Name: default
-    Color: {r: 0, g: 1, b: 0.1826632, a: 1}
+  - Name: Default
+    Color: {r: 0, g: 0, b: 0, a: 0}
     LineWidth: 10
     IsDirected: 1
     DrawEdge: 1
     ArrowheadLength: 7
     ArrowheadWidth: 7
-    Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     FontSize: 80
     FontStyle: 0
     Prefab: {fileID: 0}
@@ -2290,13 +2251,13 @@ MonoBehaviour:
     type: 3}
   EdgePrefab: {fileID: 6472097822149504536, guid: 5f50d549902958c4bbfc257f338035d6,
     type: 3}
-  SpringStiffness: 30
-  RepulsionGain: 1000000
+  SpringStiffness: 1
+  RepulsionGain: 100000
   NodeDamping: 0.5
   GreyOutFactor: 0.5
   Border: 100
-  ToolTip: {fileID: 1063538048}
-  ToolTipProperty: MostRecentDescription
+  ToolTip: {fileID: 0}
+  ToolTipProperty: 
 --- !u!222 &1392983000
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Repl/Repl.unity
+++ b/Assets/Scenes/Repl/Repl.unity
@@ -665,6 +665,50 @@ MonoBehaviour:
     FontSize: 80
     FontStyle: 0
     Prefab: {fileID: 0}
+  - Name: can be
+    Color: {r: 0.627451, g: 0.627451, b: 0.627451, a: 1}
+    LineWidth: 10
+    IsDirected: 1
+    DrawEdge: 1
+    ArrowheadLength: 7
+    ArrowheadWidth: 7
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+    FontSize: 80
+    FontStyle: 0
+    Prefab: {fileID: 0}
+  - Name: is always
+    Color: {r: 0.627451, g: 0.627451, b: 0.627451, a: 1}
+    LineWidth: 10
+    IsDirected: 1
+    DrawEdge: 1
+    ArrowheadLength: 7
+    ArrowheadWidth: 7
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+    FontSize: 80
+    FontStyle: 0
+    Prefab: {fileID: 0}
+  - Name: mutually exclusive
+    Color: {r: 1, g: 0, b: 0, a: 1}
+    LineWidth: 10
+    IsDirected: 0
+    DrawEdge: 1
+    ArrowheadLength: 7
+    ArrowheadWidth: 7
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+    FontSize: 80
+    FontStyle: 0
+    Prefab: {fileID: 0}
+  - Name: is never
+    Color: {r: 1, g: 0, b: 0, a: 1}
+    LineWidth: 10
+    IsDirected: 0
+    DrawEdge: 1
+    ArrowheadLength: 7
+    ArrowheadWidth: 7
+    Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+    FontSize: 80
+    FontStyle: 0
+    Prefab: {fileID: 0}
   NodePrefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
     type: 3}
   EdgePrefab: {fileID: 6472097822149504536, guid: 5f50d549902958c4bbfc257f338035d6,
@@ -1692,7 +1736,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 24.800283, y: 0.000030517578}
+  m_AnchoredPosition: {x: 0, y: 0.000030517578}
   m_SizeDelta: {x: -49.6, y: 0}
   m_Pivot: {x: 0.5, y: 1.0000005}
 --- !u!114 &996344458
@@ -2228,16 +2272,16 @@ MonoBehaviour:
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   NodeStyles:
-  - Name: Default
-    Color: {r: 1, g: 1, b: 1, a: 1}
+  - Name: default
+    Color: {r: 0, g: 1, b: 0.1254902, a: 1}
     Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-    FontSize: 120
+    FontSize: 80
     FontStyle: 0
     Prefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
       type: 3}
   EdgeStyles:
-  - Name: Default
-    Color: {r: 0, g: 0, b: 0, a: 0}
+  - Name: default
+    Color: {r: 0, g: 1, b: 0.1254902, a: 1}
     LineWidth: 10
     IsDirected: 1
     DrawEdge: 1
@@ -2246,18 +2290,19 @@ MonoBehaviour:
     Font: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
     FontSize: 80
     FontStyle: 0
-    Prefab: {fileID: 0}
+    Prefab: {fileID: 6472097822149504536, guid: 5f50d549902958c4bbfc257f338035d6,
+      type: 3}
   NodePrefab: {fileID: 6472097822149504536, guid: 02946b6d1e7dc33458ac04a44a85045a,
     type: 3}
   EdgePrefab: {fileID: 6472097822149504536, guid: 5f50d549902958c4bbfc257f338035d6,
     type: 3}
-  SpringStiffness: 1
+  SpringStiffness: 30
   RepulsionGain: 100000
   NodeDamping: 0.5
   GreyOutFactor: 0.5
   Border: 100
-  ToolTip: {fileID: 0}
-  ToolTipProperty: 
+  ToolTip: {fileID: 1063538048}
+  ToolTipProperty: MostRecentDescription
 --- !u!222 &1392983000
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Unity/GraphVisualization/Prefabs/Edge.prefab
+++ b/Assets/Unity/GraphVisualization/Prefabs/Edge.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &6472097822149504536
+--- !u!1 &445034987479943685
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,84 +8,50 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3402946494826849810}
-  - component: {fileID: 8003870800847919455}
-  - component: {fileID: 5307037475537206571}
-  - component: {fileID: 6972028450695676097}
-  - component: {fileID: -7578242189550859697}
-  - component: {fileID: 5844571932241428793}
+  - component: {fileID: 7056293152949258310}
+  - component: {fileID: 150429407085908712}
+  - component: {fileID: 4226654834666365520}
   m_Layer: 5
-  m_Name: Edge
+  m_Name: Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &3402946494826849810
+--- !u!224 &7056293152949258310
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6472097822149504536}
+  m_GameObject: {fileID: 445034987479943685}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 3402946494826849810}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 1.5}
---- !u!23 &8003870800847919455
-MeshRenderer:
+  m_AnchoredPosition: {x: 0, y: 50}
+  m_SizeDelta: {x: 400, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &150429407085908712
+CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6472097822149504536}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!114 &5307037475537206571
+  m_GameObject: {fileID: 445034987479943685}
+  m_CullTransparentMesh: 0
+--- !u!114 &4226654834666365520
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6472097822149504536}
+  m_GameObject: {fileID: 445034987479943685}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
@@ -125,14 +91,14 @@ MonoBehaviour:
   m_outlineColor:
     serializedVersion: 2
     rgba: 4278190080
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 80
+  m_fontSizeBase: 80
   m_fontWeight: 400
   m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMin: 16
+  m_fontSizeMax: 32
   m_fontStyle: 0
-  m_textAlignment: 257
+  m_textAlignment: 514
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
@@ -165,7 +131,7 @@ MonoBehaviour:
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
-    textComponent: {fileID: 5307037475537206571}
+    textComponent: {fileID: 4226654834666365520}
     characterCount: 10
     spriteCount: 0
     spaceCount: 2
@@ -189,6 +155,85 @@ MonoBehaviour:
   - {fileID: 0}
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &6472097822149504536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3402946494826849810}
+  - component: {fileID: 8003870800847919455}
+  - component: {fileID: 6972028450695676097}
+  - component: {fileID: -7578242189550859697}
+  - component: {fileID: 5844571932241428793}
+  m_Layer: 5
+  m_Name: Edge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3402946494826849810
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6472097822149504536}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7056293152949258310}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!23 &8003870800847919455
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6472097822149504536}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!222 &6972028450695676097
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Unity/GraphVisualization/Prefabs/Edge.prefab
+++ b/Assets/Unity/GraphVisualization/Prefabs/Edge.prefab
@@ -9,9 +9,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3402946494826849810}
+  - component: {fileID: 8003870800847919455}
+  - component: {fileID: 5307037475537206571}
   - component: {fileID: 6972028450695676097}
-  - component: {fileID: 6770987468342148256}
   - component: {fileID: -7578242189550859697}
+  - component: {fileID: 5844571932241428793}
   m_Layer: 5
   m_Name: Edge
   m_TagString: Untagged
@@ -35,18 +37,49 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 5.4203796, y: 19.7128}
-  m_SizeDelta: {x: 160, y: 30}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 1.5}
---- !u!222 &6972028450695676097
-CanvasRenderer:
+--- !u!23 &8003870800847919455
+MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6472097822149504536}
-  m_CullTransparentMesh: 0
---- !u!114 &6770987468342148256
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!114 &5307037475537206571
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -55,29 +88,115 @@ MonoBehaviour:
   m_GameObject: {fileID: 6472097822149504536}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.995283, b: 0.995283, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 1
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: New Text
+  m_text: Test  Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_textAlignment: 257
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_firstOverflowCharacterIndex: -1
+  m_linkedTextComponent: {fileID: 0}
+  m_isLinkedTextComponent: 0
+  m_isTextTruncated: 0
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 1
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_firstVisibleCharacter: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_textInfo:
+    textComponent: {fileID: 5307037475537206571}
+    characterCount: 10
+    spriteCount: 0
+    spaceCount: 2
+    wordCount: 2
+    linkCount: 0
+    lineCount: 1
+    pageCount: 1
+    materialCount: 1
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_spriteAnimator: {fileID: 0}
+  m_hasFontAssetChanged: 0
+  m_subTextObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &6972028450695676097
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6472097822149504536}
+  m_CullTransparentMesh: 0
 --- !u!114 &-7578242189550859697
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -87,7 +206,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6472097822149504536}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 975dd9f83a03f4c49bdba27cfc593aaa, type: 3}
+  m_Script: {fileID: 11500000, guid: 566aea530a0b5ec45961cd165054c321, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   StartNode: {fileID: 0}
@@ -98,8 +217,18 @@ MonoBehaviour:
     Color: {r: 1, g: 1, b: 1, a: 1}
     LineWidth: 1
     IsDirected: 1
+    DrawEdge: 1
     ArrowheadLength: 6
     ArrowheadWidth: 4
     Font: {fileID: 0}
     FontSize: 12
     FontStyle: 0
+    Prefab: {fileID: 0}
+--- !u!33 &5844571932241428793
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6472097822149504536}
+  m_Mesh: {fileID: 0}

--- a/Assets/Unity/GraphVisualization/Prefabs/Node.prefab
+++ b/Assets/Unity/GraphVisualization/Prefabs/Node.prefab
@@ -10,8 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 3402946494826849810}
   - component: {fileID: 6972028450695676097}
-  - component: {fileID: 6770987468342148256}
   - component: {fileID: 3416415107205559781}
+  - component: {fileID: 4982879157855993953}
   m_Layer: 5
   m_Name: Node
   m_TagString: Untagged
@@ -36,7 +36,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: -23.190002, y: 15.718994}
-  m_SizeDelta: {x: 261.63, y: 259.75}
+  m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.49999994, y: 0.62903243}
 --- !u!222 &6972028450695676097
 CanvasRenderer:
@@ -46,38 +46,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6472097822149504536}
   m_CullTransparentMesh: 0
---- !u!114 &6770987468342148256
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6472097822149504536}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.995283, b: 0.995283, a: 1}
-  m_RaycastTarget: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 1
-    m_LineSpacing: 1
-  m_Text: New Text
 --- !u!114 &3416415107205559781
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -87,7 +55,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 6472097822149504536}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8dfc35071b9389d40b28d3e706b54b3d, type: 3}
+  m_Script: {fileID: 11500000, guid: 573f936fb03244841ae64b9f9877a013, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   Label: 
@@ -97,6 +65,116 @@ MonoBehaviour:
     Font: {fileID: 0}
     FontSize: 12
     FontStyle: 0
-  Position: {x: 0, y: 0}
-  PreviousPosition: {x: 0, y: 0}
+    Prefab: {fileID: 0}
   NetForce: {x: 0, y: 0}
+  IsBeingDragged: 0
+--- !u!114 &4982879157855993953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6472097822149504536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Test Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_textAlignment: 257
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_firstOverflowCharacterIndex: -1
+  m_linkedTextComponent: {fileID: 0}
+  m_isLinkedTextComponent: 0
+  m_isTextTruncated: 0
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 1
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_firstVisibleCharacter: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_textInfo:
+    textComponent: {fileID: 4982879157855993953}
+    characterCount: 9
+    spriteCount: 0
+    spaceCount: 1
+    wordCount: 2
+    linkCount: 0
+    lineCount: 1
+    pageCount: 1
+    materialCount: 1
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_spriteAnimator: {fileID: 0}
+  m_hasFontAssetChanged: 0
+  m_subTextObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}

--- a/Assets/Unity/GraphVisualization/Prefabs/Node.prefab
+++ b/Assets/Unity/GraphVisualization/Prefabs/Node.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3402946494826849810}
   - component: {fileID: 6972028450695676097}
   - component: {fileID: 3416415107205559781}
-  - component: {fileID: 4982879157855993953}
+  - component: {fileID: 1264924344950949920}
   m_Layer: 5
   m_Name: Node
   m_TagString: Untagged
@@ -29,15 +29,16 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 441339263212318446}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -23.190002, y: 15.718994}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.49999994, y: 0.62903243}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6972028450695676097
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -68,13 +69,86 @@ MonoBehaviour:
     Prefab: {fileID: 0}
   NetForce: {x: 0, y: 0}
   IsBeingDragged: 0
---- !u!114 &4982879157855993953
+--- !u!114 &1264924344950949920
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6472097822149504536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.1254902}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8913619503612838761
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 441339263212318446}
+  - component: {fileID: 9218073152989428523}
+  - component: {fileID: 4706836132642106680}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &441339263212318446
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8913619503612838761}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3402946494826849810}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 150}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9218073152989428523
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8913619503612838761}
+  m_CullTransparentMesh: 0
+--- !u!114 &4706836132642106680
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8913619503612838761}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
@@ -114,21 +188,21 @@ MonoBehaviour:
   m_outlineColor:
     serializedVersion: 2
     rgba: 4278190080
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 120
+  m_fontSizeBase: 120
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_textAlignment: 257
+  m_textAlignment: 514
   m_characterSpacing: 0
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_firstOverflowCharacterIndex: -1
@@ -154,7 +228,7 @@ MonoBehaviour:
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: 0, w: 0}
   m_textInfo:
-    textComponent: {fileID: 4982879157855993953}
+    textComponent: {fileID: 4706836132642106680}
     characterCount: 9
     spriteCount: 0
     spaceCount: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2019.3.0f3
-m_EditorVersionWithRevision: 2019.3.0f3 (6c9e2bfd6f81)
+m_EditorVersion: 2019.3.0f6
+m_EditorVersionWithRevision: 2019.3.0f6 (27ab2135bccf)


### PR DESCRIPTION
Swap in TMPro to the graph/edge gameobject prefabs. Unfortunately, as it outlined at length in several commits to this and the GraphVisualizer repo, Unity friggin' nuked from orbit the settings for a lot of the handy graph style things, so many of these are reconstructed from hand.

@ianhorswill if there are inconsistencies with the old repo, I am more than happy to fix them. Just make a comment and I'll update the PR.